### PR TITLE
feat: Enable Node IP for Bambuddy

### DIFF
--- a/argocd/applications/bambuddy/templates/deployment.yaml
+++ b/argocd/applications/bambuddy/templates/deployment.yaml
@@ -16,9 +16,9 @@ spec:
     metadata:
       labels:
         {{- include "bambuddy.selectorLabels" . | nindent 8 }}
-     spec:
-       hostNetwork: true
-       containers:
+    spec:
+      hostNetwork: true
+      containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.source.image }}:{{ .Values.source.tag }}"
           imagePullPolicy: IfNotPresent

--- a/argocd/applications/bambuddy/templates/deployment.yaml
+++ b/argocd/applications/bambuddy/templates/deployment.yaml
@@ -16,8 +16,9 @@ spec:
     metadata:
       labels:
         {{- include "bambuddy.selectorLabels" . | nindent 8 }}
-    spec:
-      containers:
+     spec:
+       hostNetwork: true
+       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.source.image }}:{{ .Values.source.tag }}"
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
This PR enables the assignment of node IPs to the Bambuddy container, fulfilling the requirement to expose the service using the host's network interface.