### PR TITLE
feat(bambuddy): Enable cluster DNS resolution for bambuddy pod with h…

### DIFF
--- a/argocd/applications/bambuddy/templates/deployment.yaml
+++ b/argocd/applications/bambuddy/templates/deployment.yaml
@@ -18,6 +18,7 @@ spec:
         {{- include "bambuddy.selectorLabels" . | nindent 8 }}
     spec:
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.source.image }}:{{ .Values.source.tag }}"


### PR DESCRIPTION
…ostNetwork

Add dnsPolicy: ClusterFirstWithHostNet to allow bambuddy pod to resolve Cluster-internal service names while keeping host IP.